### PR TITLE
Added run last test functionality, menu option, and context menu option.

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -6,6 +6,7 @@
       [
         { "caption": "Run single test / scenario / spec", "command": "run_single_ruby_test" },
         { "caption": "Run all tests / feature / full spec", "command": "run_all_ruby_test" },
+        { "caption": "Run last test(s) / feature / spec", "command": "run_last_ruby_test" },
         { "caption": "-" },
         { "caption": "Show test panel", "command": "show_test_panel" },
         { "caption": "-" },

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,6 +1,7 @@
 [
   { "keys": ["ctrl+shift+r"], "command": "run_single_ruby_test" }, // single test
   { "keys": ["ctrl+shift+t"], "command": "run_all_ruby_test" }, // test file
+  { "keys": ["ctrl+shift+e"], "command": "run_last_ruby_test" }, // test file
 
   { "keys": ["ctrl+shift+x"], "command": "show_test_panel" }, // show test panel
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,7 @@
 [
   { "keys": ["super+shift+r"], "command": "run_single_ruby_test" }, // single test
   { "keys": ["super+shift+t"], "command": "run_all_ruby_test" }, // test file
+  { "keys": ["super+shift+e"], "command": "run_last_ruby_test" }, // test file
 
   { "keys": ["super+shift+x"], "command": "show_test_panel" }, // show test panel
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,6 +1,7 @@
 [
   { "keys": ["ctrl+shift+r"], "command": "run_single_ruby_test" }, // single test
   { "keys": ["ctrl+shift+t"], "command": "run_all_ruby_test" }, // test file
+  { "keys": ["ctrl+shift+e"], "command": "run_last_ruby_test" }, // test file
 
   { "keys": ["ctrl+shift+x"], "command": "show_test_panel" }, // show test panel
 

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -9,6 +9,7 @@
             [
               { "caption": "Run single test / scenario / spec", "command": "run_single_ruby_test" },
               { "caption": "Run all tests / feature / full spec", "command": "run_all_ruby_test" },
+              { "caption": "Run last tests / feature / spec", "command": "run_last_ruby_test" },
               { "caption": "-" },
               { "caption": "Show test panel", "command": "show_test_panel" },
               { "caption": "-" },

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Usage
 
  - Run single ruby test: Command-Shift-R
  - Run all ruby tests from current file: Command-Shift-T
+ - Run last ruby test(s): Command-Shift-E
  - Show test panel: Command-Shift-X
  - Check RB, ERB file syntax: Alt+Shift+V
 

--- a/RubyTest.last-run
+++ b/RubyTest.last-run
@@ -1,0 +1,4 @@
+{
+  "last_test_run": "",
+  "last_test_file": ""
+}

--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -67,6 +67,13 @@ class RunSingleRubyTest(sublime_plugin.WindowCommand):
     global CUCUMBER_UNIT_FOLDER; CUCUMBER_UNIT_FOLDER = s.get("ruby_cucumber_folder")
     global RSPEC_UNIT_FOLDER; RSPEC_UNIT_FOLDER = s.get("ruby_rspec_folder")
 
+  def save_test_run(self, ex, file_name):
+    s = sublime.load_settings("RubyTest.last-run")
+    s.set("last_test_run", ex)
+    s.set("last_test_file", file_name)
+
+    sublime.save_settings("RubyTest.last-run")
+
   def show_tests_panel(self):
     if not hasattr(self, 'output_view'):
       self.output_view = self.window.get_output_panel("tests")
@@ -152,6 +159,8 @@ class RunSingleRubyTest(sublime_plugin.WindowCommand):
       ex = self.project_path(folder_name , RSPEC_UNIT + " " + rspec_folder + file_name + " -e " + test_name)
 
     if match_obj:
+      self.save_test_run(ex, file_name)
+      
       self.show_tests_panel()
 
       self.is_running = True
@@ -181,9 +190,24 @@ class RunAllRubyTest(RunSingleRubyTest):
       sublime.error_message("Only *_test.rb, *_spec.rb, *.feature files supported!")
       return
 
+    self.save_test_run(ex, file_name)
+
     self.is_running = True
     self.proc = AsyncProcess(ex, self)
     StatusProcess("Starting tests from file " + file_name, self)
+
+class RunLastRubyTest(RunSingleRubyTest):
+  def load_last_run(self):
+    s = sublime.load_settings("RubyTest.last-run")
+    global LAST_TEST_RUN; LAST_TEST_RUN = s.get("last_test_run")
+    global LAST_TEST_FILE; LAST_TEST_FILE = s.get("last_test_file")
+
+  def run(self):
+    self.load_last_run()
+    self.show_tests_panel()
+    self.is_running = True
+    self.proc = AsyncProcess(LAST_TEST_RUN, self)
+    StatusProcess("Starting tests from file " + LAST_TEST_FILE, self)
 
 class ShowTestPanel(sublime_plugin.WindowCommand):
   def run(self):


### PR DESCRIPTION
Hey all,

I just started using your plugin today and it works great! The only missing functionality I ran into was not being able to run the last run test. I got used to this functionality when I use Rubymine and decided to add it.

Pressing Command+Shift+E will now run whatever your previously ran test was. This includes a single test or a complete test file.

This was my first time working with the Sublime plugin API so I may not have implemented it the best, but it does work. The only sketchy thing is that the state is being saved to a JSON file that will retain state even when you restart Sublime. It could be thought of as a bug/feature depending on what you want.

Thanks for open sourcing the project!

Jonathan
