### PR TITLE
highlight error when output with timing message.

### DIFF
--- a/TestConsole.tmLanguage
+++ b/TestConsole.tmLanguage
@@ -12,7 +12,7 @@
       <key>comment</key>
       <string>test pass</string>
       <key>match</key>
-      <string>\d+ (tests|assertions|examples?)</string>
+      <string>(^|\s)\d+ (tests|assertions|examples?)</string>
       <key>name</key>
       <string>test.pass</string>
     </dict>


### PR DESCRIPTION
I have a message output like below when using test/unit. And the highlight characters seems error that `7612 tests` was highlighted by mistake. A `(^|\s)` prefix fix this minor bug.

```
Run options: 

# Running tests:

....

Finished tests in 0.409786s, 9.7612 tests/s, 0.0000 assertions/s.

4 tests, 0 assertions, 0 failures, 0 errors, 0 skips
```
