### PR TITLE
Fix Linux and Windows keymaps for switching between code and spec.

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -9,7 +9,7 @@
   { "keys": ["ctrl+period"], "command": "switch_between_code_and_test", "args": {"split_view": false}, "context" : [
     { "key": "selector", "operator": "equal", "operand": "source.ruby", "match_all": true }
   ]}, // switch between code and test in single view
-  { "keys": ["ctrl+period"], "command": "switch_between_code_and_test", "args": {"split_view": true}, "context" : [
+  { "keys": ["ctrl+shift+period"], "command": "switch_between_code_and_test", "args": {"split_view": true}, "context" : [
     { "key": "selector", "operator": "equal", "operand": "source.ruby", "match_all": true }
   ]} // switch between code and test in split view
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -9,7 +9,7 @@
   { "keys": ["ctrl+period"], "command": "switch_between_code_and_test",  "args": {"split_view": false}, "context" : [
     { "key": "selector", "operator": "equal", "operand": "source.ruby", "match_all": true }
   ]}, // switch between code and test in single view
-  { "keys": ["ctrl+period"], "command": "switch_between_code_and_test",  "args": {"split_view": true}, "context" : [
+  { "keys": ["ctrl+shift+period"], "command": "switch_between_code_and_test",  "args": {"split_view": true}, "context" : [
     { "key": "selector", "operator": "equal", "operand": "source.ruby", "match_all": true }
   ]} // switch between code and test in split view
 ]


### PR DESCRIPTION
Linux and Windows keybindings for code-spec switching in split view overrides the default switch keybindings - files always open in split panes now. Fix for that.
