### PR TITLE
Fixed path to Sublime Text 2 Packages on OS X - incorrect space.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installation
 
 Go to your Sublime Text 2 `Packages` directory
 
- - OS X: `~/Library/Application Support/Sublime Text 2/Packages/`
+ - OS X: `~/Library/Application\ Support/Sublime Text 2/Packages/`
  - Windows: `%APPDATA%/Sublime Text 2/Packages/`
  - Linux: `~/.Sublime Text 2/Packages/`
 


### PR DESCRIPTION
In the terminal one needs to prefix spaces with a `\` in order for them to work correctly. I just tried copying/pasting the path name and `cd`'ing into it, but iTerm threw an error. I did it manually, and this was what worked.

<3
