### PR TITLE
Don't show terminal panel when starting tests.

### DIFF
--- a/RubyTest.sublime-settings
+++ b/RubyTest.sublime-settings
@@ -17,5 +17,7 @@
 
   "ruby_use_scratch" : false,
   "save_on_run": false,
-  "ignored_directories": [".git", "vendor", "tmp"] 
+  "ignored_directories": [".git", "vendor", "tmp"],
+
+  "hide_panel": false
 }

--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -13,6 +13,8 @@ class ShowInPanel:
   def display_results(self):
     self.panel = self.window.get_output_panel("exec")
     self.window.run_command("show_panel", {"panel": "output.exec"})
+    if HIDE_PANEL:
+      self.window.run_command("hide_panel")
     self.panel.settings().set("color_scheme", "Packages/RubyTest/TestConsole.tmTheme")
 
 
@@ -101,6 +103,7 @@ class BaseRubyTask(sublime_plugin.TextCommand):
     global RSPEC_UNIT_FOLDER; RSPEC_UNIT_FOLDER = s.get("ruby_rspec_folder")
     global USE_SCRATCH; USE_SCRATCH = s.get("ruby_use_scratch")
     global IGNORED_DIRECTORIES; IGNORED_DIRECTORIES = s.get("ignored_directories")
+    global HIDE_PANEL; HIDE_PANEL = s.get("hide_panel")
 
     if s.get("save_on_run"):
       self.window().run_command("save_all")


### PR DESCRIPTION
I've got annoyed that the terminal window showed up every time I started a test. Most of the time I don't care about the result, as long as the test passes (This feedback comes from a separate notification library)

These small changes are making it possible, to hide the panel completely when starting the tests. When a test has failed I can still get the panel by [cmd] + [shift] + [x] - This is a way more comfortable / distraction free workflow than before.

It would be nice, though, when the terminal panels shows up automatically when the tests were failing. Couldn't get this to work - any ideas?

Cheers,

Sebastian
