### PR TITLE
Add menu to access plugin preferences

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -44,5 +44,72 @@
         ]
       }
     ]
+  },
+  {
+    "caption":"Preferences",
+    "mnemonic":"n",
+    "id":"preferences",
+    "children":[
+      {
+        "caption":"Package Settings",
+        "mnemonic":"P",
+        "id":"package-settings",
+        "children":[
+          {
+            "caption":"RubyTest",
+            "children":[
+              {
+                "command":"open_file",
+                "args":{
+                  "file":"${packages}/RubyTest/RubyTest.sublime-settings"
+                },
+                "caption":"Settings – Default"
+              },
+              {
+                "command":"open_file",
+                "args":{
+                  "file":"${packages}/User/RubyTest.sublime-settings"
+                },
+                "caption":"Settings – User"
+              },
+              {
+                "caption":"-"
+              },
+              {
+                "command":"open_file",
+                "args":{
+                  "file":"${packages}/RubyTest/Default.sublime-keymap"
+                },
+                "caption":"Key Bindings – Default"
+              },
+              {
+                "command":"open_file",
+                "args":{
+                  "file":"${packages}/RubyTest/Default (Windows).sublime-keymap",
+                  "platform":"Windows"
+                },
+                "caption":"Key Bindings – User"
+              },
+              {
+                "command":"open_file",
+                "args":{
+                  "file":"${packages}/RubyTest/Default (OSX).sublime-keymap",
+                  "platform":"OSX"
+                },
+                "caption":"Key Bindings – User"
+              },
+              {
+                "command":"open_file",
+                "args":{
+                  "file":"${packages}/RubyTest/Default (Linux).sublime-keymap",
+                  "platform":"Linux"
+                },
+                "caption":"Key Bindings – User"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
It adds an menu entry 'RubyTest' to 'Sublime Text 2' -> 'Preferences' -> 'Package Settings'. 
