### PR TITLE
possible fix for minitest shoulda matcher

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -81,7 +81,7 @@ class TestMethodMatcher(object):
       if not match_obj:
         return None
       test_name = match_obj.group(1)[::-1]
-      return "%s%s%s" % ("/", test_name.replace("should", "").strip(), "/")
+      return "%s%s%s" % ("/", test_name.replace("should", "").replace("\"", "").strip(), "/")
 
 
 class RubyTestSettings:


### PR DESCRIPTION
This is a possible fix for issue #108, would please test it in your current setup? I'm using Ruby 1.9.3, with minitest, shoulda and turn (turn gem is the key, otherwise I couldn't find a matcher that would work).
