### PR TITLE
fixed non-escaped special char in TestMethodMatcher-regex

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -74,7 +74,7 @@ class TestMethodMatcher(object):
       if match_obj:
         return match_obj.group(1)[::-1]
 
-      match_obj = re.search('\s?[\"\']([a-zA-Z_\"\'\s\d-\.#=]+)[\"\']\s+tset', test_file_content) # 2nd search for 'test "name"'
+      match_obj = re.search('\s?[\"\']([a-zA-Z_\"\'\s\d\-\.#=]+)[\"\']\s+tset', test_file_content) # 2nd search for 'test "name"'
       if match_obj:
         test_name = match_obj.group(1)[::-1]
         return "test_%s" % test_name.replace("\"", "\\\"").replace(" ", "_").replace("'", "\\'")


### PR DESCRIPTION
There is a small error in the regex matching the block style definition for unittests.  I got the following exception:

```
Traceback (most recent call last):
  File "./sublime_plugin.py", line 362, in run_
  File "./run_ruby_test.py", line 249, in run
  File "./run_ruby_test.py", line 192, in run_single_test_command
  File "./run_ruby_test.py", line 66, in find_first_match_in
  File "./run_ruby_test.py", line 77, in find_first_match
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/re.py", line 142, in search
    return _compile(pattern, flags).search(string)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/re.py", line 243, in _compile
    raise error, v # invalid expression
sre_constants.error: bad character range
```

The problem was the missing escaping for the "-".
