### PR TITLE
Added file_name + '_steps.rb' as a possible alternative for feature files.

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -224,7 +224,7 @@ class BaseRubyTask(sublime_plugin.TextCommand):
     def get_project_root(self): return self.find_project_root()
 
   class CucumberFile(BaseFile):
-    def possible_alternate_files(self): return [self.file_name.replace(".feature", ".rb")]
+    def possible_alternate_files(self): return list( set( [self.file_name.replace(".feature", ".rb"), self.file_name.replace(".feature", "_steps.rb")] ) )
     def run_all_tests_command(self): return RubyTestSettings().run_cucumber_command(relative_path=self.relative_file_path())
     def run_single_test_command(self, view): return RubyTestSettings().run_single_cucumber_command(relative_path=self.relative_file_path(), line_number=self.get_current_line_number(view))
     def features(self): return ["switch_to_test", "run_test"]


### PR DESCRIPTION
I updated the Cucumber file settings to look for the corresponding '_step.rb' file names when using the command to switch between code and tests to make it easier to navigate between feature files and step definitions.

By convention, I store my feature step implementations in file_name_steps.rb files. I believe this is a pretty common convention for Cucumber. 

I love the RubyTest SwitchBetweenCodeAndTest functionality and I'm always hitting the command when reading a feature... This addresses that issue!
