### PR TITLE
Added support to switch from a Cucumber '_steps.rb' file back to the related '.feature' file.

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -246,6 +246,10 @@ class BaseRubyTask(sublime_plugin.TextCommand):
     def possible_alternate_files(self): return [self.file_name.replace(".haml", ".haml_spec.rb")]
     def features(self): return ["switch_to_test"]
 
+  class CucumberStepsFile(BaseFile):
+    def possible_alternate_files(self): return [self.file_name.replace("_steps.rb", ".feature")]
+    def features(self): return ["switch_to_test"]
+
   def find_partition_folder(self, file_name, default_partition_folder):
     folders = self.view.window().folders()
     for folder in folders:
@@ -266,6 +270,8 @@ class BaseRubyTask(sublime_plugin.TextCommand):
     elif re.search('\w+\.feature', file_name):
       partition_folder = self.find_partition_folder(file_name, CUCUMBER_UNIT_FOLDER)
       return BaseRubyTask.CucumberFile(file_name, partition_folder)
+    elif re.search('\w+\_steps.rb', file_name):
+      return BaseRubyTask.CucumberStepsFile(file_name)
     elif re.search('\w+\.rb', file_name):
       return BaseRubyTask.RubyFile(file_name)
     elif re.search('\w+\.erb', file_name):


### PR DESCRIPTION
In my previous pull request I added support to switch from '.feature' files to the related '_steps.rb' file. However, I forgot to add support for the opposite case of going from the '_steps.rb' file back to the '.feature' file. This commit adds support for that case.
