### PR TITLE
Updated plugin so that save_all is only called when running tests.

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -135,7 +135,7 @@ class BaseRubyTask(sublime_plugin.TextCommand):
       COMMAND_PREFIX = rvm_cmd + ' -S'
 
   def save_all(self):
-    if SAVE_ON_RUN
+    if SAVE_ON_RUN:
       self.window().run_command("save_all")
 
   def is_executable(self, path):


### PR DESCRIPTION
Currently, the load_config method calls save_all every method call if 'save_on_run' is enabled. This calls save_all very frequently, causing issues mentioned in #156.

This pull request changes the 'save_on_run' functionality to only call save_all when one of the run test methods is called.

Fixes #156.
