### PR TITLE
WIP: Trying to fix issue #154, Finding custom rbenv_path

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -127,7 +127,19 @@ class BaseRubyTask(sublime_plugin.TextCommand):
     global COMMAND_PREFIX; COMMAND_PREFIX = False
     global SAVE_ON_RUN; SAVE_ON_RUN = s.get("save_on_run")
 
-    rbenv_cmd = os.path.expanduser('~/.rbenv/bin/rbenv')
+    self.rbenv_or_rvm(s)
+
+  def rbenv_or_rvm(self, s):
+    which = os.popen('which rbenv').read().split('\n')[0]
+    brew = '/usr/local/bin/rbenv'
+    default = os.path.expanduser('~/.rbenv/bin/rbenv')
+    if os.path.isfile(brew):
+      rbenv_cmd = brew
+    elif os.path.isfile(which):
+      rbenv_cmd = which
+    elif os.path.isfile(default):
+      rbenv_cmd = default
+
     rvm_cmd = os.path.expanduser('~/.rvm/bin/rvm-auto-ruby')
     if s.get("check_for_rbenv") and self.is_executable(rbenv_cmd):
       COMMAND_PREFIX = rbenv_cmd + ' exec'


### PR DESCRIPTION
NOTE: This commit is a Work In Progress. Would like to get feedback from contributors/authors

Was going through issue #154 and viewed commit https://github.com/maltize/sublime-text-2-ruby-tests/commit/ed6d6a3. The code I created below doesn't work and what works is that I just pass the string `'usr/local/bin/rbenv'` to the rbenv_cmd variable. 

Have tested the below code on the Python REPL and saw that it returns the correct path. `os.popen('which rbenv').read().split('\n')[0]` returns `'usr/local/bin/rbenv'`. When I tested the code manually from ST2, it didn't work though. I hardly code in Python(only 2nd time for me, I think) so there might be something wrong with my code. 

By the way, I get the description of the which() function when I run `which rbenv` from the terminal but I get the correct output when run via Python REPL.
