### PR TITLE
allows use of line number for single unit test command

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -221,7 +221,7 @@ class BaseRubyTask(sublime_plugin.TextCommand):
       if test_name is None:
         sublime.error_message("No test name!")
         return None
-      return RubyTestSettings().run_single_ruby_unit_command(relative_path=self.relative_file_path(), test_name=test_name)
+      return RubyTestSettings().run_single_ruby_unit_command(relative_path=self.relative_file_path(), test_name=test_name, line_number=self.get_current_line_number(view))
     def features(self): return super(BaseRubyTask.UnitFile, self).features() + ["run_test"]
     def get_project_root(self): return self.find_project_root()
 


### PR DESCRIPTION
adds parameter "line_number" to "run_single_ruby_unit_command", so commands like `zeus test {relative_path} -l'{line_number}'` are possible.
