### PR TITLE
Add switch_to_test for erb templates to switch to rspec view specs.

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -243,7 +243,7 @@ class BaseRubyTask(sublime_plugin.TextCommand):
     def verify_syntax_command(self): return RubyTestSettings().erb_verify_command(file_name=self.file_name)
     def can_verify_syntax(self): return True
     def possible_alternate_files(self): return [self.file_name.replace(".erb", ".erb_spec.rb")]
-    def features(self): return ["verify_syntax","switch_to_test"]
+    def features(self): return ["verify_syntax", "switch_to_test"]
 
   class HamlFile(BaseFile):
     def possible_alternate_files(self): return [self.file_name.replace(".haml", ".haml_spec.rb")]


### PR DESCRIPTION
Hi,

since I'm using erb a lot together with rspec's view specs, I added the feature to be able to switch between erb and spec.

Additionally I fixed the haml switcher. I'm currently not using haml a lot, but looking at the implementation in line 249, which switches from .haml TO .haml_spec.rb, the other way should switch from .haml_spec.rb, not from _haml.spec.rb.

You may decide.
