### PR TITLE
Remove single quotes from around shoulda test name

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -100,7 +100,7 @@ class TestMethodMatcher(object):
       if not match_obj:
         return None
       test_name = match_obj.group(1)[::-1]
-      return "%s%s%s" % ("/", test_name.replace("should", "").replace("\"", "").strip(), "/")
+      return "%s%s%s" % ("/", test_name.replace("should", "").replace("\"", "").replace("'", "").strip(), "/")
 
 
 class RubyTestSettings:


### PR DESCRIPTION
RubyTest doesn't properly handle removing quotes from around the name of the test if single quotes are used. 
