### PR TITLE
COMMAND_PREFIX is a local variable inside rbenv_or_rvm()

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -145,6 +145,7 @@ class BaseRubyTask(sublime_plugin.TextCommand):
     if os.path.isfile(brew): rbenv_cmd = brew
     elif os.path.isfile(which): rbenv_cmd = which
 
+    global COMMAND_PREFIX
     if rbenv and self.is_executable(rbenv_cmd):
       COMMAND_PREFIX = rbenv_cmd + ' exec'
     elif rvm and self.is_executable(rvm_cmd):


### PR DESCRIPTION
This should fix the use of   

```
  "check_for_rbenv": false,
  "check_for_rvm": false,
```

preferences.
