### PR TITLE
Add creation of proper test file name if file does not end with .rb

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -481,8 +481,10 @@ class GenerateTestFile:
   def set_file_name(self, path, current_file):
     if re.search(self.test_path_re(), self.current_file()):
       return re.sub('_test.rb|_spec.rb|.feature', '.rb', current_file)
-    else:
+    elif current_file.endswith('.rb'):
       return current_file.replace('.rb', self.detect_test_type(path))
+    else:
+     return current_file+self.detect_test_type(path)
 
   def detect_test_type(self, path):
     if re.search(RUBY_UNIT_FOLDER, path):


### PR DESCRIPTION
View files mostly have a different extension than `.rb` - they end with `.erb`, `.haml` etc. The current code just returns the same name.

With this patch, when creating a spec/test file, you get a proper name suggestion instead of the same name as the view has.
