### PR TITLE
Fix incorrect detection of rspec file when  open within a folder on windows

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -289,7 +289,9 @@ class BaseRubyTask(sublime_plugin.TextCommand):
 
   def find_partition_folder(self, file_name, default_partition_folder):
     folders = self.view.window().folders()
+    file_name = file_name.replace("\\","\\\\")
     for folder in folders:
+      folder = folder.replace("\\","\\\\")
       if re.search(folder, file_name):
         return re.sub(os.sep + '.+', "", file_name.replace(folder,"")[1:])
     return default_partition_folder


### PR DESCRIPTION
On windows, when a rspec file is open within a folder, the method find_partition_folder raised an error: invalid regex due to \ as file separator
