### PR TITLE
Support spring

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -132,11 +132,17 @@ class BaseRubyTask(sublime_plugin.TextCommand):
     global THEME; THEME = s.get('theme')
 
 
-    rbenv = s.get("check_for_rbenv")
-    rvm = s.get("check_for_rvm")
+    rbenv   = s.get("check_for_rbenv")
+    rvm     = s.get("check_for_rvm")
     bundler = s.get("check_for_bundler")
+    spring  = s.get("check_for_spring")
     if rbenv or rvm: self.rbenv_or_rvm(s, rbenv, rvm)
+    if spring: self.spring_support()
     if bundler: self.bundler_support()
+    
+  def spring_support(self):
+    global COMMAND_PREFIX
+    COMMAND_PREFIX = COMMAND_PREFIX + " spring "
 
   def rbenv_or_rvm(self, s, rbenv, rvm):
     which = os.popen('which rbenv').read().split('\n')[0]


### PR DESCRIPTION
This introduces the `check_for_bundler` flag to be set in the settings file. If set to true, it will prepend the `COMMAND` with the [`spring`](https://github.com/jonleighton/spring) command.

NOTE that the documentation for spring recommends that you don't use spring from inside Bundler. So you should turn off bundler support if turning on spring support.

I'm new to writing plugins for Sublime Text, and new to Python, so please let me know, if there is something I have missed or something that should be done differently or better. 

Best regards, 

Emil
