### PR TITLE
Removed unnecessary commas from all keymaps

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -16,7 +16,7 @@
   { "keys": ["ctrl+shift+e"], "command": "run_last_ruby_test",
     "context": [ { "key": "selector", "operator": "equal",
 		   "operand": "source.ruby, source.rspec, text.gherkin.feature"
-               } ], // test last test file
+               } ] // test last test file
   },
 
   { "keys": ["ctrl+shift+x"], "command": "show_test_panel" }, // show test panel

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -16,7 +16,7 @@
   { "keys": ["super+shift+e"], "command": "run_last_ruby_test",
     "context": [ { "key": "selector", "operator": "equal",
 		   "operand": "source.ruby, source.rspec, text.gherkin.feature"
-               } ], // test last test file
+               } ] // test last test file
   },
 
   { "keys": ["super+shift+x"], "command": "show_test_panel" }, // show test panel

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -16,7 +16,7 @@
   { "keys": ["ctrl+shift+e"], "command": "run_last_ruby_test",
     "context": [ { "key": "selector", "operator": "equal",
 		   "operand": "source.ruby, source.rspec, text.gherkin.feature"
-               } ], // test last test file
+               } ] // test last test file
   },
 
   { "keys": ["ctrl+shift+x"], "command": "show_test_panel" }, // show test panel


### PR DESCRIPTION
Solving the problem: _Error trying to parse file: s before closing bracket in ~/Library/Application Support/Sublime Text 2/Packages/RubyTest/Default (OSX).sublime-keymap:20:3_
