### PR TITLE
Fix keybind on Linux and Windows

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -35,7 +35,7 @@
                } ]
   }, // switch between code and test in single mode
 
-  { "keys": ["ctrl+ctrl+period"],
+  { "keys": ["ctrl+shift+period"],
       "command": "switch_between_code_and_test",
       "args": {"split_view": true},
       "context": [ { "key": "selector", "operator": "equal",

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -35,7 +35,7 @@
                } ]
   }, // switch between code and test in single mode
 
-  { "keys": ["ctrl+ctrl+period"],
+  { "keys": ["ctrl+shift+period"],
       "command": "switch_between_code_and_test",
       "args": {"split_view": true},
       "context": [ { "key": "selector", "operator": "equal",


### PR DESCRIPTION
When I press "ctrl+period", don't execute `"command": "switch_between_code_and_test", "args": {"split_view": false}` on linux.
