### PR TITLE
Remove 'Run last test' command's keybinding context

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -13,11 +13,7 @@
   }, // test file
 
 
-  { "keys": ["ctrl+shift+e"], "command": "run_last_ruby_test",
-    "context": [ { "key": "selector", "operator": "equal",
-		   "operand": "source.ruby, source.rspec, text.gherkin.feature"
-               } ]
-  }, // test last test file
+  { "keys": ["ctrl+shift+e"], "command": "run_last_ruby_test" }, // test last test file
 
   { "keys": ["ctrl+shift+x"], "command": "show_test_panel" }, // show test panel
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -13,11 +13,7 @@
   }, // test file
 
 
-  { "keys": ["super+shift+e"], "command": "run_last_ruby_test",
-    "context": [ { "key": "selector", "operator": "equal",
-		   "operand": "source.ruby, source.rspec, text.gherkin.feature"
-               } ]
-  }, // test last test file
+  { "keys": ["super+shift+e"], "command": "run_last_ruby_test" }, // test last test file
 
   { "keys": ["super+shift+x"], "command": "show_test_panel" }, // show test panel
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -13,11 +13,7 @@
   }, // test file
 
 
-  { "keys": ["ctrl+shift+e"], "command": "run_last_ruby_test",
-    "context": [ { "key": "selector", "operator": "equal",
-		   "operand": "source.ruby, source.rspec, text.gherkin.feature"
-               } ]
-  }, // test last test file
+  { "keys": ["ctrl+shift+e"], "command": "run_last_ruby_test" }, // test last test file
 
   { "keys": ["ctrl+shift+x"], "command": "show_test_panel" }, // show test panel
 


### PR DESCRIPTION
Sometimes I want to run the last test when I'm on a Rails view file. I have to switch to a ruby file just so I can run the last test. This commit removes that limitation.

Thank you.
