### PR TITLE
fix single test syntax for Rspec 3.xx

### DIFF
--- a/RubyTest.sublime-settings
+++ b/RubyTest.sublime-settings
@@ -9,7 +9,7 @@
   "run_single_cucumber_command": "cucumber {relative_path} -l{line_number}",
 
   "run_rspec_command": "rspec {relative_path}",
-  "run_single_rspec_command": "rspec {relative_path} -l{line_number}",
+  "run_single_rspec_command": "rspec {relative_path}:{line_number}",
 
   "ruby_unit_folder": "test",
   "ruby_cucumber_folder": "features",


### PR DESCRIPTION
In Rspec 3.xx the `-l` option to specify line number is no longer supported.
You can still pass the line using `rspec spec/some_spec.rb:10` (where 10 is the line number)
I simply edited the command default RubyTest command for rspec single test to reflect this.

I hope this helps.
