### PR TITLE
Allows settings to be overwritten on a per-project base

### DIFF
--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -112,6 +112,9 @@ class RubyTestSettings:
   def __getattr__(self, name):
     if not self.settings.has(name):
       raise AttributeError(name)
+    value = sublime.active_window().active_view().settings().get(name)
+    if value:
+      return lambda **kwargs: value.format(**kwargs)
     return lambda **kwargs: self.settings.get(name).format(**kwargs)
 
 


### PR DESCRIPTION
If you create a `settings` area on your `Project.sublime-project` file and you override settings of the original `RubyTest.sublime-settings` file, it will read the properties from that file that instead.

Example (used on a Rails 3.2 project that uses Spring binstubs for RSpec):

``` javascript
{
    "folders":
    [
        {
            "follow_symlinks": true,
            "path": "crm_bliss"
        }
    ],
    "settings":
    {
        "run_rspec_command": "bundle exec bin/rspec {relative_path}",
        "run_single_rspec_command": "bundle exec bin/rspec {relative_path}:{line_number}",
    }
}
```
