### PR TITLE
add "internal_dir" option to sublime-settings

### DIFF
--- a/RubyTest.sublime-settings
+++ b/RubyTest.sublime-settings
@@ -32,6 +32,8 @@
   "theme": "Packages/RubyTest/TestConsole.hidden-tmTheme",
   "syntax": "Packages/RubyTest/TestConsole.tmLanguage",
 
-  "terminal_encoding": "utf-8"
+  "terminal_encoding": "utf-8",
 
+  // the internal project directory where ruby code is located and "spec" directory presented
+  "internal_dir": "."
 }

--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -134,7 +134,7 @@ class BaseRubyTask(sublime_plugin.TextCommand):
     global SYNTAX; SYNTAX = s.get('syntax')
     global THEME; THEME = s.get('theme')
     global TERMINAL_ENCODING; TERMINAL_ENCODING = s.get('terminal_encoding')
-
+    global INTERNAL_DIR; INTERNAL_DIR = s.get("internal_dir")
 
     rbenv   = s.get("check_for_rbenv")
     rvm     = s.get("check_for_rvm")
@@ -202,6 +202,9 @@ class BaseRubyTask(sublime_plugin.TextCommand):
     self.save_test_run(command, working_dir)
     if COMMAND_PREFIX:
       command = COMMAND_PREFIX + ' ' + command
+    if INTERNAL_DIR and INTERNAL_DIR != ".":
+      command = re.sub(r"" + INTERNAL_DIR + "\/", "", command)
+      working_dir += "/" + INTERNAL_DIR
     if int(sublime.version().split('.')[0]) <= 2:
       command = [command]
     self.view.window().run_command("exec", {


### PR DESCRIPTION
Sometimes when project is large and written at several languages, the ruby code could be placed in some internal directory. The `spec` directory where tests of ruby code is implemented also placed in it internal directory. For example see my project: [versatile-diamond](/newmen/versatile-diamond)/analyzer
Current patch adds option to `sublime-settings` by which the internal directory could be set.