### PR TITLE
Fix built command when ussing bundle and spring 

### DIFF
--- a/package-metadata.json
+++ b/package-metadata.json
@@ -1,4 +1,5 @@
 {
+  "name": "RubyTest",
   "url": "https://github.com/maltize/sublime-text-2-ruby-tests",
   "version": "1.0.0",
   "description": "Sublime Text 2 plugin for running ruby tests! (Unit, RSpec, Cucumber)",

--- a/run_ruby_test.py
+++ b/run_ruby_test.py
@@ -141,8 +141,8 @@ class BaseRubyTask(sublime_plugin.TextCommand):
     bundler = s.get("check_for_bundler")
     spring  = s.get("check_for_spring")
     if rbenv or rvm: self.rbenv_or_rvm(s, rbenv, rvm)
-    if spring: self.spring_support()
     if bundler: self.bundler_support()
+    if spring: self.spring_support()
 
   def spring_support(self):
     global COMMAND_PREFIX


### PR DESCRIPTION
The command is built as `spring bundle rspec` instead of `bundle spring rspec`.